### PR TITLE
Group tasks by status

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
 import './index.css';
-import { TaskList } from './components/TaskList';
+import { GroupedTaskList } from './components/GroupedTaskList';
 
 function App() {
   return (
     <main className="min-h-screen bg-gray-100">
       <h1 className="text-2xl font-bold text-center py-6">Lista de Tareas</h1>
-      <TaskList />
+      <GroupedTaskList />
     </main>
   );
 }

--- a/src/components/GroupedTaskList.tsx
+++ b/src/components/GroupedTaskList.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { getTasks } from '../services/taskService';
+import type { Task } from '../types/task';
+
+type GroupedTasks = Record<Task['status'], Task[]>;
+
+function groupByStatus(tasks: Task[]): GroupedTasks {
+  return {
+    'Por hacer': tasks.filter((t) => t.status === 'Por hacer'),
+    'En progreso': tasks.filter((t) => t.status === 'En progreso'),
+    Completada: tasks.filter((t) => t.status === 'Completada'),
+  };
+}
+
+export function GroupedTaskList() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getTasks()
+      .then(setTasks)
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p className="text-center mt-10">Cargando tareas...</p>;
+
+  const grouped = groupByStatus(tasks);
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4">
+      {Object.entries(grouped).map(([status, tasks]) => (
+        <div key={status} className="bg-gray-100 rounded shadow-sm p-2">
+          <h2 className="text-lg font-semibold text-center mb-2">{status}</h2>
+          <div className="flex flex-col gap-2">
+            {tasks.map((task) => (
+              <div
+                key={task.id}
+                className="bg-white p-3 rounded shadow border hover:shadow-md transition"
+              >
+                <p className="font-medium">{task.name}</p>
+                <p className="text-sm text-gray-600">
+                  {task.priority} - {new Date(task.due_date).toLocaleDateString()}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
### Context
Now that we have a basic view for all the tasks, we need to put all the tasks into categories to have a more organized view.

### Changes
- Add categories for the tasks
- Remove the status from each card since the cards will be inside categories representing the status
- Add the new component to the main page

### Result
Now all the tasks will be inside a category and the user won't have to scroll to see all the cards.
<img width="1872" height="316" alt="image" src="https://github.com/user-attachments/assets/f00e2c74-b34d-4852-8fdc-28aed7ed5df2" />
