### PR TITLE
Feature/edit task

### DIFF
--- a/src/components/EditTaskModal.tsx
+++ b/src/components/EditTaskModal.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import type { Task } from '../types/task';
+import { updateTask } from '../services/taskService';
+
+interface Props {
+  task: Task;
+  onClose: () => void;
+  onUpdated: (task: Task) => void;
+}
+
+export function EditTaskModal({ task, onClose, onUpdated }: Props) {
+  const [form, setForm] = useState({
+    name: task.name,
+    priority: task.priority,
+    status: task.status,
+    due_date: task.due_date,
+    description: task.description || '',
+    image_url: task.image_url || '',
+  });
+
+  const [error, setError] = useState('');
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async () => {
+    if (form.name.trim().length < 3 || form.name.trim().length > 50) {
+      setError('El nombre debe tener entre 3 y 50 caracteres');
+      return;
+    }
+
+    try {
+      const updated = await updateTask(task.id, {
+        ...form,
+        name: form.name.trim(),
+        priority: form.priority as Task['priority'],
+        status: form.status as Task['status'],
+      });
+
+      onUpdated(updated);
+      onClose();
+    } catch (err) {
+      console.error(err);
+      setError('Error al actualizar la tarea');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center z-50">
+      <div className="bg-white p-6 rounded shadow-md w-full max-w-md">
+        <h2 className="text-lg font-semibold mb-4">Editar tarea</h2>
+        <input
+          type="text"
+          name="name"
+          placeholder="Nombre"
+          className="border p-2 w-full mb-2"
+          value={form.name}
+          onChange={handleChange}
+        />
+        <input
+          type="date"
+          name="due_date"
+          className="border p-2 w-full mb-2"
+          value={form.due_date}
+          onChange={handleChange}
+        />
+        <select
+          name="priority"
+          className="border p-2 w-full mb-2"
+          value={form.priority}
+          onChange={handleChange}
+        >
+          <option value="Baja">Baja</option>
+          <option value="Media">Media</option>
+          <option value="Alta">Alta</option>
+        </select>
+        <select
+          name="status"
+          className="border p-2 w-full mb-2"
+          value={form.status}
+          onChange={handleChange}
+        >
+          <option value="Por hacer">Por hacer</option>
+          <option value="En progreso">En progreso</option>
+          <option value="Completada">Completada</option>
+        </select>
+        <input
+          type="text"
+          name="image_url"
+          placeholder="URL de imagen (opcional)"
+          className="border p-2 w-full mb-2"
+          value={form.image_url}
+          onChange={handleChange}
+        />
+        <textarea
+          name="description"
+          placeholder="Descripción (opcional)"
+          className="border p-2 w-full mb-2"
+          value={form.description}
+          onChange={handleChange}
+        />
+        {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} className="px-4 py-2 border rounded">
+            Cancelar
+          </button>
+          <button onClick={handleSubmit} className="bg-blue-600 text-white px-4 py-2 rounded">
+            Guardar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GroupedTaskList.tsx
+++ b/src/components/GroupedTaskList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { getTasks, deleteTask } from '../services/taskService';
 import { CreateTaskModal } from './CreateTaskModal';
+import { EditTaskModal } from './EditTaskModal';
 import type { Task } from '../types/task';
 
 type GroupedTasks = Record<Task['status'], Task[]>;
@@ -17,6 +18,7 @@ export function GroupedTaskList() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
+  const [taskToEdit, setTaskToEdit] = useState<Task | null>(null);
 
   useEffect(() => {
     getTasks()
@@ -58,6 +60,7 @@ export function GroupedTaskList() {
                 <div
                   key={task.id}
                   className="bg-white p-3 rounded shadow border hover:shadow-md transition relative"
+                  onClick={() => setTaskToEdit(task)}
                 >
                   <p className="font-medium">{task.name}</p>
                   <p className="text-sm text-gray-600">
@@ -79,6 +82,15 @@ export function GroupedTaskList() {
         <CreateTaskModal
           onClose={() => setShowModal(false)}
           onCreated={(newTask) => setTasks((prev) => [...prev, newTask])}
+        />
+      )}
+      {taskToEdit && (
+        <EditTaskModal
+          task={taskToEdit}
+          onClose={() => setTaskToEdit(null)}
+          onUpdated={(updatedTask) =>
+            setTasks((prev) => prev.map((t) => (t.id === updatedTask.id ? updatedTask : t)))
+          }
         />
       )}
     </>

--- a/src/components/GroupedTaskList.tsx
+++ b/src/components/GroupedTaskList.tsx
@@ -59,18 +59,29 @@ export function GroupedTaskList() {
               {tasks.map((task) => (
                 <div
                   key={task.id}
-                  className="bg-white p-3 rounded shadow border hover:shadow-md transition relative"
-                  onClick={() => setTaskToEdit(task)}
+                  className="bg-white p-4 rounded shadow border hover:shadow-md transition relative"
                 >
-                  <p className="font-medium">{task.name}</p>
+                  <p className="font-medium mt-4">{task.name}</p>
                   <p className="text-sm text-gray-600">
                     {task.priority} - {new Date(task.due_date).toLocaleDateString()}
                   </p>
                   <button
-                    onClick={() => handleDelete(task.id)}
-                    className="absolute top-2 right-2 text-sm text-red-500 hover:text-red-700"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(task.id);
+                    }}
+                    className="absolute top-2 right-2 text-sm bg-red-600 text-white rounded w-6 h-6 flex items-center justify-center hover:bg-red-700"
                   >
                     X
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setTaskToEdit(task);
+                    }}
+                    className="absolute top-2 left-2 bg-blue-600 text-white rounded w-6 h-6 flex items-center justify-center text-sm hover:bg-blue-700"
+                  >
+                    ✎
                   </button>
                 </div>
               ))}

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -47,3 +47,22 @@ export async function createTask(data: Omit<Task, 'id'>): Promise<Task> {
   const [newTask] = await response.json();
   return newTask;
 }
+
+export async function updateTask(id: number, data: Partial<Omit<Task, 'id'>>): Promise<Task> {
+  const response = await fetch(`${API_URL}?id=eq.${id}`, {
+    method: 'PATCH',
+    headers: {
+      apikey: API_KEY,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    throw new Error('Error actualizando tarea');
+  }
+
+  const [updatedTask] = await response.json();
+  return updatedTask;
+}
+


### PR DESCRIPTION
### Context
There's no need to delete a task when the user makes a mistake, sometimes editing a task is more than enough for the user. The objective with these changes is to implement an edit modal, make sure that the data shown in the edit modal is the same as the clicked card.

### Changes
- Add edit modal
- Add edit/PUT function in the service
- Add edit button on each card
- Add edit function to open the edit modal

### Result
Now is possible to edit a task. In addition, the CRUD for the tasks is complete.
<img width="220" height="100" alt="image" src="https://github.com/user-attachments/assets/f27a72ce-b0da-48be-92e3-98c97aaf6856" />
